### PR TITLE
Paper reproduction discrepancies (issue #10) - work in progress

### DIFF
--- a/experiments/README.MD
+++ b/experiments/README.MD
@@ -95,7 +95,7 @@ everywhere):
   the trained policy per task at the end of its training into `runs/<run_name>/`, and upload it
   to wandb if `--use-wandb` is on. VDN/QMIX video is Q-value-argmax based (verified only
   against Overcooked).
-- `--log-interval <int>` (default `5`, MAPPO defaults to `75`) — how often (in update steps)
+- `--log-interval <int>` (default `5`, matching paper Table 6) — how often (in update steps)
   to compute/log metrics; TensorBoard scalars only actually hit disk every `flush_secs`
   (tensorboardX default 120s) or on process exit — for continuous mid-run wandb sync on short
   runs you'd need to lower that in `experiments/algo_common.py`.

--- a/experiments/algos/mappo.py
+++ b/experiments/algos/mappo.py
@@ -29,7 +29,6 @@ from experiments.utils import Transition_MAPPO, batchify, init_cl_state, unbatch
 class MAPPOConfig(OnPolicyConfig):
     alg_name: Literal["ippo", "mappo"] = "mappo"
     use_agent_id: bool = True  # MAPPO-specific: append agent one-hot to actor obs
-    log_interval: int = 75
     shared_backbone: bool = False
     regularize_critic: bool = False
 


### PR DESCRIPTION
Working through the 8 points raised in #10 one at a time, each as its own commit so the reasoning/decision for each is traceable.

Addresses #10 (not "Fixes", since this is still in progress across all 8 points).

**Point 1 - evaluation interval (done):** MAPPOConfig overrode `log_interval` to 75 with no documented rationale, while IPPO/HAPPO/VDN/QMIX default to 5 (matching paper Table 6). Unified to 5. Table 6 is treated as authoritative over Section 5's body text ("every 100 updates"), which looks like a paper typo given how dense the per-task eval curves in Figs 3/23-25 are.

Remaining points 2-8 to follow as separate commits.