### PR TITLE
Fix MAPPO agent id issue

### DIFF
--- a/experiments/algos/mappo.py
+++ b/experiments/algos/mappo.py
@@ -215,8 +215,15 @@ class MAPPO(OnPolicyAlgo):
                     obs_batch = batchify(last_obs, agents, cfg.num_actors, not cfg.use_cnn)
                     global_state = create_global_state_for_critic(last_obs, agents, cfg.num_envs, cfg.use_cnn)
 
+                    # batchify() always produces the blocked layout (all envs for agent 0,
+                    # then all envs for agent 1, ...), so this is the true per-row agent id.
+                    # Computed explicitly (rather than left to the Actor's fallback) so the
+                    # same array can be stored in the transition and carried through the
+                    # PPO update's flatten+shuffle
+                    agent_id_batch = jnp.arange(cfg.num_actors) // cfg.num_envs
+
                     pi, _actor_dormant = actor_network.apply(
-                        train_state.params['actor'], obs_batch, env_idx=env_idx
+                        train_state.params['actor'], obs_batch, env_idx=env_idx, agent_id=agent_id_batch
                     )
                     value_per_env, _critic_dormant = critic_network.apply(
                         train_state.params['critic'], global_state, env_idx=env_idx
@@ -246,7 +253,7 @@ class MAPPO(OnPolicyAlgo):
                         batchify(done, agents, cfg.num_actors, not cfg.use_cnn).squeeze(),
                         action, value,
                         batchify(reward, agents, cfg.num_actors).squeeze(),
-                        log_prob, obs_batch, global_state_batch,
+                        log_prob, obs_batch, global_state_batch, agent_id_batch,
                     )
                     steps_for_env = steps_for_env + cfg.num_envs
                     runner_state = (train_state, env_state, obsv, update_step, steps_for_env, rng, cl_state)
@@ -276,7 +283,9 @@ class MAPPO(OnPolicyAlgo):
                             local_obs = traj_batch.obs
                             global_state = traj_batch.global_state
 
-                            pi, _ = actor_network.apply(params['actor'], local_obs, env_idx=env_idx)
+                            pi, _ = actor_network.apply(
+                                params['actor'], local_obs, env_idx=env_idx, agent_id=traj_batch.agent_id
+                            )
                             value, _ = critic_network.apply(params['critic'], global_state, env_idx=env_idx)
                             log_prob = pi.log_prob(traj_batch.action)
 

--- a/experiments/model/decoupled_mlp.py
+++ b/experiments/model/decoupled_mlp.py
@@ -71,7 +71,7 @@ class Actor(nn.Module):
     dormant_threshold: float = 0.01
 
     @nn.compact
-    def __call__(self, x, *, env_idx: int = 0):
+    def __call__(self, x, *, env_idx: int = 0, agent_id: jnp.ndarray = None):
         # Choose the activation function based on input parameter.
         act_fn = nn.relu if self.activation == "relu" else nn.tanh
 
@@ -90,12 +90,17 @@ class Actor(nn.Module):
 
         # -------- append agent ID one-hot ------------------------------------
         if self.use_agent_id:
-            # Create agent IDs based on batch position
-            # In MAPPO, observations are batched with all envs for agent 0, then all envs for agent 1, etc.
-            # So agent_id = batch_position // num_envs
-            batch_size = x.shape[0]
-            agent_ids = jnp.arange(batch_size) // self.num_envs
-            agent_onehot = jax.nn.one_hot(agent_ids, self.num_agents)
+            if agent_id is None:
+                # Fallback for callers that don't pass an explicit agent_id (e.g. eval,
+                # importance-fn rollouts): batchify() always produces the blocked layout.
+                # All envs for agent 0, then all envs for agent 1, etc. so
+                # batch_position // num_envs recovers each row's true agent id.
+                # This does NOT hold once a batch has been flattened+shuffled (as PPO's
+                # minibatch construction does), which is why the training loop passes
+                # agent_id explicitly instead of relying on this fallback.
+                batch_size = x.shape[0]
+                agent_id = jnp.arange(batch_size) // self.num_envs
+            agent_onehot = jax.nn.one_hot(agent_id, self.num_agents)
             x = jnp.concatenate([x, agent_onehot], axis=-1)
 
         # Hidden layers

--- a/experiments/utils.py
+++ b/experiments/utils.py
@@ -38,6 +38,7 @@ class Transition_MAPPO(NamedTuple):
     log_prob: jnp.ndarray  # the log probability of the action
     obs: jnp.ndarray  # the observation
     global_state: jnp.ndarray  # the global state for centralized critic
+    agent_id: jnp.ndarray  # true agent id per row, carried through shuffling/minibatching
 
 
 def batchify(x, agent_list, num_actors, flatten=True):


### PR DESCRIPTION
Fix MAPPO's agent-ID conditioning. The actor derived agent identity from post-shuffle minibatch row position, which no longer matched the true agent after PPO's flatten+permute step, so it now carries an explicit `agent_id` through the transition instead of re-deriving it. Resolves #11 (2).